### PR TITLE
Add Mlflow model api endpoints

### DIFF
--- a/checkpoint/README.md
+++ b/checkpoint/README.md
@@ -18,6 +18,15 @@ Model approval layer for your model registry.
 pip install -e .
 ```
 
+To run the server:
+
+```bash
+FLASK_APP=checkpoint.app \
+FLASK_ENV=development \
+CHECKPOINT_REGISTRY_URL=http://YOUR_MFLOW_HOST \
+flask run
+```
+
 ## Linting / Testing
 
 To run our linting/testing:

--- a/checkpoint/checkpoint/models.py
+++ b/checkpoint/checkpoint/models.py
@@ -1,12 +1,7 @@
 from sqlalchemy import Column, Integer, String, Enum  # type: ignore
 from checkpoint.database import CheckpointBase
+from checkpoint.types import ModelVersionStage
 import enum
-
-
-class ModelVersionStage(enum.Enum):
-    NONE = "none"
-    STAGING = "staging"
-    PRODUCTION = "production"
 
 
 class PromoteRequestStatus(enum.Enum):

--- a/checkpoint/checkpoint/registries.py
+++ b/checkpoint/checkpoint/registries.py
@@ -1,0 +1,82 @@
+from checkpoint.types import ModelVersionStage, ModelVersion, Model
+from mlflow.tracking import MlflowClient  # type: ignore
+from mlflow.exceptions import RestException  # type: ignore
+
+from typing import List
+import logging
+from abc import ABC, abstractmethod
+
+logger = logging.getLogger(__name__)
+
+
+class RegistryException(Exception):
+    def __init__(self, cause: Exception):
+        self.cause = cause
+
+
+class Registry(ABC):
+    @abstractmethod
+    def list_models(self) -> List[Model]:
+        pass
+
+    @abstractmethod
+    def list_model_versions(self, model_name: str) -> List[ModelVersion]:
+        pass
+
+    @abstractmethod
+    def transition_model_version(
+        self, version: ModelVersion, target_stage: ModelVersionStage
+    ):
+        pass
+
+
+class MlflowRegistry(Registry):
+    STAGE_MAPPING = {
+        ModelVersionStage.PRODUCTION: "Production",
+        ModelVersionStage.STAGING: "Staging",
+        ModelVersionStage.NONE: "None",
+        ModelVersionStage.ARCHIVED: "Archived",
+    }
+
+    def __init__(self, registry_uri, tracking_uri) -> None:
+        self.client = MlflowClient(
+            registry_uri=registry_uri, tracking_uri=tracking_uri
+        )
+        logger.info("Mlflow Registry initialized.")
+
+    def list_models(self) -> List[Model]:
+        models = [Model(m.name) for m in self.client.list_registered_models()]
+        logger.info(f"Fetched {len(models)}Models from MLFlow.")
+        return models
+
+    def list_model_versions(self, model_name: str) -> List[ModelVersion]:
+        versions = self.client.get_latest_versions(
+            model_name, self.STAGE_MAPPING.values()
+        )
+
+        if len(versions) >= 1:
+            latest_version_number = max([int(v.version) for v in versions])
+            print(latest_version_number)
+
+            return [
+                ModelVersion(id=str(i), model_name=model_name)
+                for i in range(1, latest_version_number + 1)
+            ]
+        else:
+            return []
+
+        return super().list_model_versions(model_name)
+
+    def transition_model_version(
+        self, version: ModelVersion, target_stage: ModelVersionStage
+    ):
+        try:
+            self.client.transition_model_version_stage(
+                name=version.model_name,
+                version=int(version.id),
+                stage=self.STAGE_MAPPING[target_stage],
+                archive_existing_versions=True,
+            )
+        except RestException as e:
+            logger.error(e)
+            raise RegistryException(e)

--- a/checkpoint/checkpoint/types.py
+++ b/checkpoint/checkpoint/types.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+import enum
+
+
+class ModelVersionStage(enum.Enum):
+    NONE = "none"
+    ARCHIVED = "archived"
+    STAGING = "staging"
+    PRODUCTION = "production"
+
+
+@dataclass
+class Model:
+    name: str
+
+
+@dataclass
+class ModelVersion:
+    model_name: str
+    id: str

--- a/checkpoint/setup.py
+++ b/checkpoint/setup.py
@@ -9,10 +9,11 @@ setuptools.setup(
     url="https://github.com/dominodatalab/domino-research/checkpoint",
     packages=setuptools.find_packages(),
     install_requires=[
+        "beautifulsoup4==4.9",
         "Flask==2.0",
         "flask-sqlalchemy==2.5.1",
+        "mlflow==1.19",
         "requests==2.26",
-        "beautifulsoup4==4.9",
     ],
     entry_points={"console_scripts": ["checkpoint = checkpoint.app:main"]},
 )


### PR DESCRIPTION
- Adds `/models` and `/models/<name>/versions` routes to the API
- Backs these routes with an `MlflowRegistry` that subclasses a generic `Registry`
